### PR TITLE
Upgrade sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Alternative front-end for YouTube
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://docs.piped.video/)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://piped.video/)
-[![Version: 2026.01.24~ynh1](https://img.shields.io/badge/Version-2026.01.24~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/piped/)
+[![Version: 2026.01.24~ynh2](https://img.shields.io/badge/Version-2026.01.24~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/piped/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/piped"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -8,7 +8,7 @@ name = "Piped"
 description.en = "Alternative front-end for YouTube"
 description.fr = "Interface alternative pour YouTube"
 
-version = "2026.01.24~ynh1"
+version = "2026.01.24~ynh2"
 
 maintainers = [ "orhtej2" ]
 
@@ -60,10 +60,10 @@ ram.runtime = "50M"
         autoupdate.upstream = "https://github.com/TeamPiped/piped-proxy/"
 
         [resources.sources.jdk]
-        amd64.url = "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.9%2B10/OpenJDK21U-jdk_x64_linux_hotspot_21.0.9_10.tar.gz"
-        amd64.sha256 = "810d3773df7e0d6c4394e4e244b264c8b30e0b05a0acf542d065fd78a6b65c2f"
-        arm64.url = "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.9%2B10/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.9_10.tar.gz"
-        arm64.sha256 = "edf0da4debe7cf475dbe320d174d6eed81479eb363f41e38a2efb740428c603a"
+        amd64.url = "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.10%2B7/OpenJDK21U-jdk_x64_linux_hotspot_21.0.10_7.tar.gz"
+        amd64.sha256 = "ea3b9bd464d6dd253e9a7accf59f7ccd2a36e4aa69640b7251e3370caef896a4"
+        arm64.url = "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.10%2B7/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.10_7.tar.gz"
+        arm64.sha256 = "357fee29fb0d5c079f6730db98b28942df13a6eed426f6c61cd4ad703ab27b9a"
         autoupdate.strategy = "latest_github_release"
         autoupdate.version_regex = "jdk-(\\d+\\.\\d+\\.\\d+)\\+(.*)"
         autoupdate.upstream = "https://github.com/adoptium/temurin21-binaries"


### PR DESCRIPTION
Upgrade sources
- `jdk` v21.0.10.7: https://github.com/adoptium/temurin21-binaries/releases/tag/jdk-21.0.10%2B7